### PR TITLE
Ignore v-deep when evaluating selector-pseudo-element-no-unknown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-tc",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-tc",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Stylelint shareable config",
   "keywords": [
     "stylelint",

--- a/rules/possibleErrors.js
+++ b/rules/possibleErrors.js
@@ -14,7 +14,7 @@ module.exports = {
     'declaration-block-no-shorthand-property-overrides': true,
     'block-no-empty': true,
     'selector-pseudo-class-no-unknown': true,
-    'selector-pseudo-element-no-unknown': true,
+    'selector-pseudo-element-no-unknown': [true, {ignorePseudoElements: 'v-deep'}],
     'selector-type-no-unknown': true,
     'media-feature-name-no-unknown': true,
     'at-rule-no-unknown': [


### PR DESCRIPTION
Ignore v-deep when evaluating selector-pseudo-element-no-unknown