### PR TITLE
Remove macos testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         node: [10, 12, 14]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I'm not 100% sure why, but testing on macOS continues to get hung up for this repo. I don't think it is adding a lot of value at this point so would like to remove it vs. digging in to a ton of details. Feel free to reject this if you disagree.